### PR TITLE
Added Gruvbox themes

### DIFF
--- a/android/assets/themes/gruvbox-dark.theme
+++ b/android/assets/themes/gruvbox-dark.theme
@@ -1,0 +1,26 @@
+{
+    "name": "Gruvbox Dark",
+    "price": 30,
+    "colors": {
+        "background": "282828ff",
+        "foreground": "ffffffff",
+        "buttons": [
+            "b8bb26ff",
+            "fabd2fff",
+            "83a598ff",
+            "fb4934ff"
+        ],
+        "empty_cell": "504945ff",
+        "cells": [
+            "458588ff", "8ec07cff", "689d6aff",
+            "fabd2fff", "d79921ff", "d3869bff", "fb4934ff",
+            "83a598ff", "98971aff"
+        ],
+        "current_score": "fabd2fff",
+        "high_score": "8ec07cff",
+        "bonus": "ebdbb2ff",
+        "band": "458588ff",
+        "text": "ffffffff"
+    },
+    "cell_texture": "basic.png"
+}

--- a/android/assets/themes/gruvbox-light.theme
+++ b/android/assets/themes/gruvbox-light.theme
@@ -1,0 +1,26 @@
+{
+    "name": "Gruvbox Light",
+    "price": 30,
+    "colors": {
+        "background": "fbf1c7ff",
+        "foreground": "fbf1c7ff",
+        "buttons": [
+            "98971aff",
+            "d79921ff",
+            "458588ff",
+            "cc241dff"
+        ],
+        "empty_cell": "ebdbb2ff",
+        "cells": [
+            "8f3f71ff", "689d6aff", "b16286ff",
+            "458588ff", "d79921ff", "98971aff", "cc241dff",
+            "076678ff", "427b58ff"
+        ],
+        "current_score": "d79921ff",
+        "high_score": "689d6aff",
+        "bonus": "3c3836ff",
+        "band": "458588ff",
+        "text": "fbf1c7ff"
+    },
+    "cell_texture": "basic.png"
+}

--- a/android/assets/themes/theme.list
+++ b/android/assets/themes/theme.list
@@ -1,6 +1,8 @@
 default
 dark
 darcula
+gruvbox-light
+gruvbox-dark
 winter
 spring
 summer


### PR DESCRIPTION
Added light and dark Gruvbox theme.
Prices are set to 30 coins for both of them, you may want to adjust that.

![klooni1010_gruvbox](https://user-images.githubusercontent.com/32850922/31845022-188aa44e-b5fd-11e7-8680-066ca81c442e.png)
