### PR TITLE
Disable resizable property for desktop configuration to avoid stretching of images

### DIFF
--- a/core/src/dev/lonami/klooni/screens/MainMenuScreen.java
+++ b/core/src/dev/lonami/klooni/screens/MainMenuScreen.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.utils.viewport.FitViewport;
 
 import dev.lonami.klooni.Klooni;
 import dev.lonami.klooni.actors.SoftButton;
@@ -57,6 +58,7 @@ public class MainMenuScreen extends InputListener implements Screen {
         Table table = new Table();
         table.setFillParent(true);
         stage.addActor(table);
+        stage.setViewport(new FitViewport(Klooni.GAME_WIDTH, Klooni.GAME_HEIGHT));
 
         // Play button
         final SoftButton playButton = new SoftButton(

--- a/desktop/src/dev/lonami/klooni/desktop/DesktopLauncher.java
+++ b/desktop/src/dev/lonami/klooni/desktop/DesktopLauncher.java
@@ -29,7 +29,6 @@ class DesktopLauncher {
         config.title = "Klooni 1010!";
         config.width = Klooni.GAME_WIDTH;
         config.height = Klooni.GAME_HEIGHT;
-        config.resizable = false;
         config.addIcon("ic_launcher/icon128.png", Files.FileType.Internal);
         config.addIcon("ic_launcher/icon32.png", Files.FileType.Internal);
         config.addIcon("ic_launcher/icon16.png", Files.FileType.Internal);

--- a/desktop/src/dev/lonami/klooni/desktop/DesktopLauncher.java
+++ b/desktop/src/dev/lonami/klooni/desktop/DesktopLauncher.java
@@ -29,6 +29,7 @@ class DesktopLauncher {
         config.title = "Klooni 1010!";
         config.width = Klooni.GAME_WIDTH;
         config.height = Klooni.GAME_HEIGHT;
+        config.resizable = false;
         config.addIcon("ic_launcher/icon128.png", Files.FileType.Internal);
         config.addIcon("ic_launcher/icon32.png", Files.FileType.Internal);
         config.addIcon("ic_launcher/icon16.png", Files.FileType.Internal);


### PR DESCRIPTION
The game would stretch and look really bad if it was resized when running on desktop, so I disabled resizing in the DesktopLauncher class.