### PR TITLE
Make app movable to SD card

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.lonami.klooni" >
+    package="dev.lonami.klooni"
+    android:installLocation="auto">
 
     <application
         android:allowBackup="true"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,8 @@ android {
         //noinspection MinSdkTooLow
         minSdkVersion 8
         targetSdkVersion 29
-        versionCode 840
-        versionName "0.8.4"
+        versionCode 850
+        versionName "0.8.5"
     }
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     apply plugin: "eclipse"
 
-    version = '0.8.4'
+    version = '0.8.5'
     ext {
         appName = "1010! Klooni"
         gdxVersion = '1.9.10'


### PR DESCRIPTION
## Rationale
Over 25% of the world's Android devices still run Android 6.0 or older [[1]](https://www.androidauthority.com/android-version-distribution-748439/). This version of Android still has native support for moving applications to SD cards — this is crucial when dealing with low-storage devices. Many more recent OEM OSes also support moving applications to SD cards. This means making applications movable to the SD card is IMHO a rational choice.

## Solution
Add `android:installLocation="auto"` flag to AndroidMainfest.xml. The default for Android is, curiously, not `"auto"` but `"internalOnly"`

https://developer.android.com/guide/topics/data/install-location

Signed-off-by: Atrate <Atrate@protonmail.com>